### PR TITLE
basic docker image extending jh-minimal-nb

### DIFF
--- a/docker/jupyterhub-trustyai/Dockerfile
+++ b/docker/jupyterhub-trustyai/Dockerfile
@@ -10,5 +10,6 @@ RUN apt-get update && apt-get install -qq --yes --no-install-recommends \
 RUN apt-get update && apt-get install -qq --yes --no-install-recommends \
     default-jdk
 
+
 # install TrustyAI python package...
 RUN pip install trustyai

--- a/docker/jupyterhub-trustyai/Dockerfile
+++ b/docker/jupyterhub-trustyai/Dockerfile
@@ -6,10 +6,9 @@ RUN apt-get update && apt-get install -qq --yes --no-install-recommends \
     curl
 
 
-# install
+# install JVM
 RUN apt-get update && apt-get install -qq --yes --no-install-recommends \
-    default-jdk \
-    maven
+    default-jdk
 
 # install TrustyAI python package...
 RUN pip install trustyai

--- a/docker/jupyterhub-trustyai/Dockerfile
+++ b/docker/jupyterhub-trustyai/Dockerfile
@@ -1,0 +1,15 @@
+FROM jupyter/minimal-notebook:latest
+
+USER root
+
+RUN apt-get update && apt-get install -qq --yes --no-install-recommends \
+    curl
+
+
+# install
+RUN apt-get update && apt-get install -qq --yes --no-install-recommends \
+    default-jdk \
+    maven
+
+# install TrustyAI python package...
+RUN pip install trustyai


### PR DESCRIPTION
This provides a first basic JupyterHub docker image extending from `jupyter/minimal-notebook`